### PR TITLE
Recipe for definition of environment variables

### DIFF
--- a/recipes/environment.rb
+++ b/recipes/environment.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: windev
+# Recipe:: environment
+#
+# Copyright (c) 2015 Zühlke, All Rights Reserved.
+
+node.fetch('environment',{}).each do |k,v|
+  env k do
+    name k
+    value v
+    action :create
+  end
+end


### PR DESCRIPTION
In the spirit of packages and features allows us to define a Hash that is then interpreted as names=values for environment variables:

```
"environment":{
  "PATH":C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\",
      "GIT_SSL_NO_VERIFY":"true",
      "devmgr_show_nonpresent_devices":"1"
    }
```