### PR TITLE
Add 3010 to acceptable return codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,29 @@
+# 0.5.1
+ * Add return code 3010 (requires reboot) back to the list of acceptable return codes for package installers
+ * Update windows cookbook dependency to 2.1.1
 # 0.5.0
-unpack option for installers packaged in zip files
-
-updated all development and cookbook dependencies
+ * unpack option for installers packaged in zip files
+ * updated all development and cookbook dependencies
 
 # 0.4.0
-Chocolatey integration
+ * Chocolatey integration
 
 # 0.3.3
-Fixed a bug in the caching of installers
-
+ * Fixed a bug in the caching of installers
 # 0.3.2
-Conformed to foodcritic warnings
-
-Removed some obsolete cruft
-
+ * Conformed to foodcritic warnings
+ * Removed some obsolete cruft
 # 0.3.1
-Depot directory creation is now recursive
-
-Fixed the license metadata
-
+ * Depot directory creation is now recursive
+ * Fixed the license metadata
 # 0.3.0
-Removed the SSL recipe
-
-Added the environment recipe
-
-Bugfixes in the handling of empty node attributes for cache,packages and drivers
+ * Removed the SSL recipe
+ * Added the environment recipe
+ * Bugfixes in the handling of empty node attributes for cache,packages and drivers
 
 #  0.2.0
-Caching and driver installation implemented as LWRPs
-
-Package installation uses caching and packages are downloaded only when not installed and not already cached
+ * Caching and driver installation implemented as LWRPs
+ * Package installation uses caching and packages are downloaded only when not installed and not already cached
 
 #  0.1.0
 Initial release of windev

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Zühlke
+Copyright (c) 2015-2016 Zühlke
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email 'var@zuehlke.com'
 license          'MIT'
 description      'Configures Windows'
 long_description 'Configures a Windows installation. Parameters include the list of Windows features to remove and data on the installer packages to be added'
-version          '0.5.0'
+version          '0.5.1'
 issues_url 'https://github.com/Zuehlke/cookbook-windev/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/Zuehlke/cookbook-windev' if respond_to?(:source_url)
 
 supports 'windows'
 
-depends 'windows',"~>2.0.2"
+depends 'windows',"~>2.1.1"
 depends 'chocolatey',"~>1.0.3"

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -47,6 +47,7 @@ node.fetch('installer_packages',[]).each do |pkg|
       options pkg['options']
       version pkg['version']
       timeout pkg.fetch('timeout',600)
+      returns [0,3010]
       action :install
     end
   end


### PR DESCRIPTION
When a restart is required and /norestart is passed to MSI the recipe will fail. Fix it.

Also updated cookbook dependencies for windows