### PR TITLE
Recipe to rerun chef (or any script) after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.0
+ * Add the auto_chef/remove_auto_chef recipes
+
 # 0.5.1
  * Add return code 3010 (requires reboot) back to the list of acceptable return codes for package installers
  * Update windows cookbook dependency to 2.1.1

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#All-in-one Windows development environments
+# All-in-one Windows development environments
 
 [![Build Status](https://travis-ci.org/Zuehlke/cookbook-windev.svg)](http://travis-ci.org/Zuehlke/cookbook-windev)
 
 One cookbook with recipes and resources for setting up a Windows development environment.
 
-##Why not use [chocolatey](https://github.com/chocolatey/chocolatey-cookbook)?
+## Why not use [chocolatey](https://github.com/chocolatey/chocolatey-cookbook)?
 
 Please do if it suits you!
 
@@ -12,9 +12,7 @@ There's also a convenience wrapper for chocolatey added to windev since 0.4.0.
 
 Having said that, controlling the installation location is more obvious in windev. The idea is that in windev you choose the installer yourself so configuration is more prominent and it's easier to figure out the custom arguments required.
 
-##Recipes
-
-##[depot.rb](recipes/depot.rb)
+## [depot.rb](recipes/depot.rb)
 
 This recipe just sets up the local software cache. It is used by all recipes that install software.
 
@@ -40,7 +38,7 @@ You can define a node attribute 'cache' to specify packages to download and cach
 
 *This is a helper feature for downloading packages that are later manually installed (as is the case with unsigned drivers). Generally it is not needed if the installers are well behaved (but many are not).*
 
-##[features.rb](recipes/features.rb)
+## [features.rb](recipes/features.rb)
 
 The features recipe:
 
@@ -59,7 +57,7 @@ Example:
 }
 ```
 
-##[drivers.rb](recipes/drivers.rb)
+## [drivers.rb](recipes/drivers.rb)
 
 Installs Windows drivers using dpinst.
 
@@ -79,11 +77,11 @@ The certificate should either be a part of the driver package or provided in the
 
 *This recipe is for the moment specific to 64bit Windows installations. For drivers whose publisher is untrusted you will need to include the publisher's certificate in the cookbook. It will not work at all with unsigned drivers*
 
-##[packages.rb](recipes/packages.rb)
+## [packages.rb](recipes/packages.rb)
 
 This recipe provides three ways for software installation: installer-driven, from a zip file or through [chocolatey](https://chocolatey.org/).
 
-###Installer driven
+### Installer driven
 
 The `installer_packages` attribute expects an array of installer definitions.
 
@@ -121,14 +119,9 @@ The installers need to be capable of operating unattended (silent or quiet mode)
     }
   ]
 }
-
-
-
 ```
 
-
-
-###Zip files
+### Zip files
 
 The `zip_packages` attribute expects an array of zip definitions.
 
@@ -156,7 +149,7 @@ Example:
 }
 ```
 
-###Chocolatey
+### Chocolatey
 
 The `choco_packages` attribute expects an array of chocolatey package definitions.
 
@@ -169,7 +162,7 @@ Each package definition is a hash with parameters:
 
 All parameters but `name` are optional. Chocolatey will only be installed if choco_packages is not empty
 
-##[environment.rb](recipes/environment.rb)
+## [environment.rb](recipes/environment.rb)
 
 Provides an easy way to define environment variables in JSON configurations.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'var@zuehlke.com'
 license          'MIT'
 description      'Configures Windows'
 long_description 'Configures a Windows installation. Parameters include the list of Windows features to remove and data on the installer packages to be added'
-version          '0.5.1'
+version          '0.6.0'
 issues_url 'https://github.com/Zuehlke/cookbook-windev/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/Zuehlke/cookbook-windev' if respond_to?(:source_url)
 

--- a/recipes/auto_chef.rb
+++ b/recipes/auto_chef.rb
@@ -1,0 +1,42 @@
+#
+# Cookbook Name:: windev
+# Recipe:: auto_chef
+#
+# Author:: Vassilis Rizopoulos (<var@zuehlke.com>)
+#
+# Copyright (c) 2014-2016 Zühlke, All Rights Reserved.
+
+#Create a user to restart the process after booting
+user "chef-auto-start" do
+  comment "Chef installation user"
+  password 'chef-auto-start'
+  action :create
+end
+#add the user to the administrators group
+group "Administrators" do
+  action :modify
+  members "chef-auto-start"
+  append true
+end
+#Set up autologin for chef-auto-start
+registry_key "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\WinLogon" do 
+  values [{:name => "AutoAdminLogin",:type => :string,:data => "1"}, 
+    {:name => "AutoAdminLogon",:type => :string,:data => "1"}, 
+    {:name => "DefaultUserName",:type => :string,:data => "chef-auto-start"},
+    {:name => "DefaultPassword",:type => :string,:data => "chef-auto-start"}
+  ]
+  action :create
+end
+
+#Register the chef command to run on startup
+cmd=ENV["CHEF_SCRIPT"]
+raise "CHEF_SCRIPT not defined, cannot register Chef for startup" unless cmd
+cmd_params=ENV["CHEF_CONFIG"]
+cmd_params||=node.fetch("chef",{})["config"]
+raise "No chef configuration attribute defined. Add node[\"chef\"][\"config\"] to your configuration or define CHEF_CONFIG" unless cmd_params
+
+windows_auto_run 'Chef Run' do
+  program cmd
+  args    "#{cmd_params}"
+  action  :create
+end

--- a/recipes/auto_chef.rb
+++ b/recipes/auto_chef.rb
@@ -7,6 +7,13 @@
 # Copyright (c) 2014-2016 Zühlke, All Rights Reserved.
 
 #Create a user to restart the process after booting
+
+cmd=ENV["CHEF_SCRIPT"]
+raise "windev::auto_chef: CHEF_SCRIPT not defined, cannot register Chef for startup" unless cmd
+cmd_params=ENV["CHEF_CONFIG"]
+cmd_params||=node.fetch("chef",{})["config"]
+raise "windev::auto_chef: No Chef configuration attribute defined. Add node[\"chef\"][\"config\"] to your configuration or define CHEF_CONFIG" unless cmd_params
+
 user "chef-auto-start" do
   comment "Chef installation user"
   password 'chef-auto-start'
@@ -27,14 +34,7 @@ registry_key "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersio
   ]
   action :create
 end
-
 #Register the chef command to run on startup
-cmd=ENV["CHEF_SCRIPT"]
-raise "CHEF_SCRIPT not defined, cannot register Chef for startup" unless cmd
-cmd_params=ENV["CHEF_CONFIG"]
-cmd_params||=node.fetch("chef",{})["config"]
-raise "No chef configuration attribute defined. Add node[\"chef\"][\"config\"] to your configuration or define CHEF_CONFIG" unless cmd_params
-
 windows_auto_run 'Chef Run' do
   program cmd
   args    "#{cmd_params}"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: windev
 # Recipe:: default
 #
-# Copyright (C) 2015 YOUR_NAME
+# Author:: Vassilis Rizopoulos (<var@zuehlke.com>)
 #
-# All rights reserved - Do Not Redistribute
+# Copyright (c) 2014-2016 Zühlke, All Rights Reserved.
 #

--- a/recipes/remove_auto_chef.rb
+++ b/recipes/remove_auto_chef.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: windev
+# Recipe:: auto_chef
+#
+# Author:: Vassilis Rizopoulos (<var@zuehlke.com>)
+#
+# Copyright (c) 2014-2016 Zühlke, All Rights Reserved.
+
+#Create a user to restart the process after booting
+user "chef-auto-start" do
+  comment "Chef installation user"
+  password 'chef-auto-start'
+  force true
+  action :remove
+end
+#Set up autologin for chef-auto-start
+registry_key "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\WinLogon" do 
+  values [{:name => "AutoAdminLogin",:type => :string,:data => "0"}, 
+    {:name => "AutoAdminLogon",:type => :string,:data => "0"}, 
+    {:name => "DefaultUserName",:type => :string,:data => ""},
+    {:name => "DefaultPassword",:type => :string,:data => ""}
+  ]
+  action :create
+end
+
+windows_auto_run 'Chef Run' do
+  program "echo"
+  args    ""
+  action  :remove
+end


### PR DESCRIPTION
The realities of Windows installations require that we reboot several times before finishing.

windev conceptually operates autonomously from a Chef server as a single Chef client invocation, so restarting the run is a complicated issue.

windev::chef_auto allows us to work around this problem:  It registers "CHEF_SCRIPT CHEF_CONFIG" as a startup script, where CHEF_SCRIPT and CHEF_CONFIG environment variables.

(To do this it needs to do a lot more stuff: create an admin user, set auto login, register the script etc.)