### PR TITLE
Fixes in attributes/default.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['software_depot']="software"
 default['drivers']=[]
-default['windows_packages']=[]
+default['installer_packages']=[]
 default['zip_packages']=[]
 default['windows_features']={"remove"=>["MediaPlayback","WindowsMediaPlayer","MediaCenter","TabletPCOC","FaxServicesClientPackage",
         "Xps-Foundation-Xps-Viewer","Printing-XPSServices-Features"]}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,5 @@ default['software_depot']="software"
 default['drivers']=[]
 default['installer_packages']=[]
 default['zip_packages']=[]
-default['windows_features']={"remove"=>["MediaPlayback","WindowsMediaPlayer","MediaCenter","TabletPCOC","FaxServicesClientPackage",
-        "Xps-Foundation-Xps-Viewer","Printing-XPSServices-Features"]}
+default['windows_features']={"remove"=>[]}
 default.environment={}


### PR DESCRIPTION
This PR introduces some changes to `attributes/default.rb`:

1. Rename "windows_packages" to "installer_packages" in default attributes. I could find no reference to "windows_packages" anywhere in the recipes, so I assume this should be "installer_packages" instead.

2. Don't remove any windows feature by default
