### PR TITLE
WIP - Add support for interpreting options flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ The `choco_packages` attribute expects an array of chocolatey package definition
 Each package definition is a hash with parameters:
 
   * name - name of the package
-  * source
+  * source - the source from which to install the package (choco `--source` flag)
   * version - version of the package to use
-  * args - arguments to the installation
+  * options - commandline options to be passed to chocolatey
+  * args - arguments to be passed to the underlying native installer (choco `--install-arguments` flag)
 
 All parameters but `name` are optional. Chocolatey will only be installed if choco_packages is not empty
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -32,7 +32,7 @@ node.fetch('installer_packages',[]).each do |pkg|
     else
       installer= ::File.join(node["software_depot"],pkg['save_as'])
     end
-    
+
     ruby_block "installer_exists" do
       block do
         raise "Installer #{File.expand_path(installer)} not found" unless File.exist?(File.expand_path(installer))
@@ -43,7 +43,7 @@ node.fetch('installer_packages',[]).each do |pkg|
     package pkg['name'] do # ~FC009
       provider Chef::Provider::Package::Windows
       source File.expand_path(installer)
-      installer_type pkg['type'].to_sym if pkg['type'] 
+      installer_type pkg['type'].to_sym if pkg['type']
       options pkg['options']
       version pkg['version']
       timeout pkg.fetch('timeout',600)
@@ -73,7 +73,7 @@ node.fetch('zip_packages',[]).each do |pkg|
       source installer
       action :unzip
     end
-    file version do 
+    file version do
       action :create
     end
   end
@@ -89,11 +89,13 @@ choco_packages.each do |pkg|
   if pkg["name"]
     pkg_source=pkg.fetch("source","")
     pkg_args=pkg.fetch("args","")
+    pkg_options=pkg.fetch("options","")
     pkg_version=pkg.fetch("version","")
     chocolatey pkg["name"] do
       version pkg_version unless pkg_version.empty?
       source pkg_source unless pkg_source.empty?
       args pkg_args unless pkg_args.empty?
+      options pkg_options unless pkg_options.empty?
       action :install
     end
   end


### PR DESCRIPTION
**WIP - don't merge yet.** - I just discovered that `options` need to be passed as a hash, not a string...

Currently we can pass only `args` to the chocolatey resource. This PR adds support for passing `options` as well.

The difference:

 * what you pass as `args` will be passed down to the native installer in the package via choco's `--install-arguments='<args>'` commandline option
 * what you pass as `options` will be passed to the choco installer directly

See:
https://github.com/chocolatey/chocolatey-cookbook#resource-properties
https://github.com/chocolatey/choco/wiki/CommandsInstall