### PR TITLE
Fix Resource Cloning warnings

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -33,7 +33,7 @@ node.fetch('installer_packages',[]).each do |pkg|
       installer= ::File.join(node["software_depot"],pkg['save_as'])
     end
 
-    ruby_block "installer_exists" do
+    ruby_block "#{installer} exists" do
       block do
         raise "Installer #{File.expand_path(installer)} not found" unless File.exist?(File.expand_path(installer))
       end


### PR DESCRIPTION
use unique resource name to get rid of resource cloning deprecation warnings (see https://docs.chef.io/deprecations_resource_cloning.html)

Before this PR you would get these warnings at the end of the chef run:

```
Deprecated features used!
  Cloning resource attributes for ruby_block[installer_exists] from prior resource
Previous ruby_block[installer_exists]: C:/repos/jsm/tools/infrastructure/windows_development/.chef/cache/cookbooks/windev/recipes/packages.rb:36:in `block in from_file'
Current  ruby_block[installer_exists]: C:/repos/jsm/tools/infrastructure/windows_development/.chef/cache/cookbooks/windev/recipes/packages.rb:36:in `block in from_file' at 1 location:
    - C:/repos/jsm/tools/infrastructure/windows_development/.chef/cache/cookbooks/windev/recipes/packages.rb:36:in `block in from_file'
   See https://docs.chef.io/deprecations_resource_cloning.html for further details.
````

With this PR these are gone ;)
