### PR TITLE
Add valid exit codes for choco packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.8.3
+  * Allow 3010 as a valid return code for a chocolatey package and add exit_codes to config for custom entries
 # 0.8.2
   * Add handling of params (concatenates params with --parameters onto the options)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Each package definition is a hash with parameters:
   * version - version of the package to use
   * options - commandline options to be passed to chocolatey directly
   * params - options to be passed to the package installer (the --package option).
-
+  * exit_codes - An optional list of additional exit codes allowed. If given an exit code within the list it will be interpreted as successful installation. Default is an empty list.
+  
 All parameters but `name` are optional.
 
 Example: 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'var@zuehlke.com'
 license          'MIT'
 description      'Configures Windows'
 long_description 'Configures a Windows installation. Parameters include the list of Windows features to remove and data on the installer packages to be added'
-version          '0.8.2'
+version          '0.8.3'
 chef_version '>= 12.7' if respond_to?(:chef_version)
 issues_url 'https://github.com/Zuehlke/cookbook-windev/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/Zuehlke/cookbook-windev' if respond_to?(:source_url)

--- a/recipes/choco_packages.rb
+++ b/recipes/choco_packages.rb
@@ -28,6 +28,7 @@ choco_packages.each do |pkg|
       version pkg_version unless pkg_version.empty?
       source pkg_source unless pkg_source.empty?
       options pkg_options unless pkg_options.empty?
+      returns [0,3010] + pkg.fetch('exit_codes', [])
       action :install
     end
   end


### PR DESCRIPTION
3010 (requires reboot) should not make Chef error out.

Added a s a valid code and added the 'exit_codes' configuration parameter (analog to installer_packages entries) to allow for custom valid exit codes.

Bump version to 0.8.3 as a bugfix