### PR TITLE
Update windev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ pkg/
 .vagrant
 Berksfile.lock
 # Bundler
-Gemfile.lock
 bin/*
 .bundle/*
 *.bak

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
+before_install: gem update bundler
 rvm:
-  - 2.4.5
+  - 2.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,89 @@
-# 0.8.4
-  * Update windows cookbook version
-  * Ensure setting environment default does not break on Chef13 (kimo)
-# 0.8.3
-  * Allow 3010 as a valid return code for a chocolatey package and add exit_codes to config for custom entries
-# 0.8.2
-  * Add handling of params (concatenates params with --parameters onto the options)
+# windev changelog
 
-# 0.8.1
-  * Upgrade foodcritic and handle the deprecations.
-  * Reintroduce the chocolatey dependency as we need it to install chocolatey.
+## 1.0.0
+
+* Require Chef >=14
+* Update windows cookbook dependency
+* Update chocolatey cookbook dependency
+* Remove god mode trick
+* Clean up the documentation
+* Update the development environment (ruby 2.6, newest bundler and gems)
+
+## 0.8.4
+
+* Update windows cookbook version
+* Ensure setting environment default does not break on Chef13 (kimo)
+
+## 0.8.3
+
+* Allow 3010 as a valid return code for a chocolatey package and add exit_codes to config for custom entries
+
+## 0.8.2
+
+* Add handling of params (concatenates params with --parameters onto the options)
+
+## 0.8.1
+
+* Upgrade foodcritic and handle the deprecations.
+* Reintroduce the chocolatey dependency as we need it to install chocolatey.
   
-# 0.8.0
-  * Chocolatey support now uses the Chef resource.
-  * Chef dependency now >=12.7
-  * Removed dependency to chocolatey cookbook
+## 0.8.0
 
-# 0.7.0
- * Allow custom acceptable return codes in package installer config (MarkusPalcer)
- * Updated all cookbook and gem dependencies.
- * It's now Chef >12.6
- * Fixed default attribut values (tknerr)
- * Allow setting of options for chockolatey (tknerr)
+* Chocolatey support now uses the Chef resource.
+* Chef dependency now >=12.7
+* Removed dependency to chocolatey cookbook
 
-# 0.6.0
- * Add the auto_chef/remove_auto_chef recipes
+## 0.7.0
 
-# 0.5.1
- * Add return code 3010 (requires reboot) back to the list of acceptable return codes for package installers
- * Update windows cookbook dependency to 2.1.1
+* Allow custom acceptable return codes in package installer config (MarkusPalcer)
+* Updated all cookbook and gem dependencies.
+* It's now Chef >12.6
+* Fixed default attribut values (tknerr)
+* Allow setting of options for chockolatey (tknerr)
 
-# 0.5.0
- * unpack option for installers packaged in zip files
- * updated all development and cookbook dependencies
+## 0.6.0
 
-# 0.4.0
- * Chocolatey integration
+* Add the auto_chef/remove_auto_chef recipes
 
-# 0.3.3
- * Fixed a bug in the caching of installers
+## 0.5.1
 
-# 0.3.2
- * Conformed to foodcritic warnings
- * Removed some obsolete cruft
+* Add return code 3010 (requires reboot) back to the list of acceptable return codes for package installers
+* Update windows cookbook dependency to 2.1.1
 
-# 0.3.1
- * Depot directory creation is now recursive
- * Fixed the license metadata
+## 0.5.0
 
-# 0.3.0
- * Removed the SSL recipe
- * Added the environment recipe
- * Bugfixes in the handling of empty node attributes for cache,packages and drivers
+* unpack option for installers packaged in zip files
+* updated all development and cookbook dependencies
 
-#  0.2.0
- * Caching and driver installation implemented as LWRPs
- * Package installation uses caching and packages are downloaded only when not installed and not already cached
+## 0.4.0
 
-#  0.1.0
+* Chocolatey integration
+
+## 0.3.3
+
+* Fixed a bug in the caching of installers
+
+## 0.3.2
+
+* Conformed to foodcritic warnings
+* Removed some obsolete cruft
+
+## 0.3.1
+
+* Depot directory creation is now recursive
+* Fixed the license metadata
+
+## 0.3.0
+
+* Removed the SSL recipe
+* Added the environment recipe
+* Bugfixes in the handling of empty node attributes for cache,packages and drivers
+
+## 0.2.0
+
+* Caching and driver installation implemented as LWRPs
+* Package installation uses caching and packages are downloaded only when not installed and not already cached
+
+## 0.1.0
+
 Initial release of windev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0
 
 * Require Chef >=14
+* Allow for chocolatey package upgrades
 * Update windows cookbook dependency
 * Update chocolatey cookbook dependency
 * Remove god mode trick

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 group :development do
-  gem 'foodcritic', "~>15.1.0", :require => false
-  gem "stove","~>7.0.1", :require => false
+  gem 'foodcritic', "~>16.0.0", :require => false
+  gem "stove","~>7.1.0", :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,50 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backports (3.15.0)
+    chef-api (0.9.0)
+      logify (~> 0.1)
+      mime-types
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-tag_expressions (1.1.1)
+    erubis (2.7.0)
+    ffi-yajl (2.3.1)
+      libyajl2 (~> 1.2)
+    foodcritic (16.0.0)
+      cucumber-core (>= 1.3, < 4.0)
+      erubis
+      ffi-yajl (~> 2.0)
+      nokogiri (>= 1.5, < 2.0)
+      rake
+      rufus-lru (~> 1.0)
+      treetop (~> 1.4)
+    gherkin (5.1.0)
+    libyajl2 (1.2.0)
+    logify (0.2.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
+    polyglot (0.3.5)
+    rake (12.3.2)
+    rufus-lru (1.1.0)
+    stove (7.1.0)
+      chef-api (~> 0.5)
+      logify (~> 0.2)
+    treetop (1.6.10)
+      polyglot (~> 0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  foodcritic (~> 16.0.0)
+  stove (~> 7.1.0)
+
+BUNDLED WITH
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ Each package definition is a hash with parameters:
   
 All parameters but `name` are optional.
 
-Example:
+**Examples:**
+
+Install a chocolatey package
 
 ```json
 {
@@ -134,6 +136,21 @@ Example:
       "name":"Ruby",
       "version":"2.4.3.1",
       "params":"/InstallDir=c:\\tools\\ruby"
+    }
+  ]
+}
+```
+
+Upgrade a package
+
+```json
+{
+  "choco_packages": [
+    {
+      "name":"Ruby",
+      "version":"2.4.3.1",
+      "params":"/InstallDir=c:\\tools\\ruby",
+      "upgrade":true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -4,98 +4,14 @@
 
 One cookbook with recipes and resources for setting up a Windows development environment.
 
-## Why not use [chocolatey](https://github.com/chocolatey/chocolatey-cookbook)?
+Its main focus is in providing a configuration-driven way of installing software from the variety of installer formats, zip archives and the chocolatey package manager.
+It also allows you to uninstall Windows features and set environment variables on the system level.
 
-Please do. windev offers a convenience wrapper for chocolatey just like it does for plain installers and zip archives. Check the doc for choco_packages. - it only depends on the availability of the packages you need.
+## windev::packages
 
-## [auto_chef](recipes/auto_chef.rb)
+[packages.rb](recipes/packages.rb) provides three ways for software installation: installer-driven, from a zip file or through [chocolatey](https://chocolatey.org/).
 
-auto_chef works around the need to reboot Windows multiple times during a Chef run.
-
-It creates a temporary admin user and registers an auto logon script so that in case of a reboot the run can continue.
-
-The auto logon script is controlled via the environment variables CHEF_SCRIPT and CHEF_CONFIG.
-
-CHEF_SCRIPT is the script and CHEF_CONFIG is passed as a parameter to it.
-
-The remove_auto_chef recipe undoes all changes effected by auto_chef.
-
-The idea is you use auto_chef in the beginning, add any recipes that require or cause reboots and as long as you don't get yourself in an endless reboot loop you clean up at the end with remove_auto_chef.
-
-*NOTE for users of vagrant*: if you are running your scripts from c:\vagrant then auto_chef will inexplicably do nothing.
-
-This happens because Windows runs the startup scripts before mounting the network shares, so the startup fails to find the script.
-
-## [depot.rb](recipes/depot.rb)
-
-This recipe just sets up the local software cache. It is used by all recipes that install software.
-
-The location of the local software is specified in the 'software_depot' attribute.
-
-The default value for 'software_depot' is 'software', which will create the directory at the point of chef's execution.
-
-Example:
-
-```ruby
-{"software_depot": "software"}
-```
-
-You can define a node attribute 'cache' to specify packages to download and cache locally in software_depot.
-'cache' is an array of hashes:
-
-```ruby
-{
-  "software_depot": "software",
-  "cache":[{"source":"http://bin.repo/foo.zip","save_as":"foo.zip"}]
-}
-```
-
-*This is a helper feature for downloading packages that are later manually installed (as is the case with unsigned drivers). Generally it is not needed if the installers are well behaved (but many are not).*
-
-## [features.rb](recipes/features.rb)
-
-The features recipe:
-
- * Creates a GodMode folder<sup>1</sup>
- * Deactivates the action center
- * Deactivates the Windows firewall
-
-and uninstalls a list of Windows features provided in `node['windows_features']['remove']`
-
-Example:
-
-```ruby
-{"windows_features": {
-    "remove": ["MediaPlayback","WindowsMediaPlayer","MediaCenter","TabletPCOC","FaxServicesClientPackage",
-        "Xps-Foundation-Xps-Viewer","Printing-XPSServices-Features","Internet-Explorer-Optional-amd64"]}
-}
-```
-
-## [drivers.rb](recipes/drivers.rb)
-
-Installs Windows drivers using dpinst.
-
-The way it works is that it expects a zip file with the driver files (the .inf and .cat file etc.) that also contains the dpinst utility. The LWRP is relatively smart and will match several versions of the dpinst filename (dpinst_amd64, dpinst_x64 etc.). It will also create an automation configuration (dpinst.xml) if one is not provided.
-
-Optionally you can provide a certificate (add it to the files/default in the cookbook) to be added to the trusted publishers in the windows certificate store.
-
-The certificate should either be a part of the driver package or provided in the cookbook's files.
-
-```ruby
-"drivers":[
-    {"name":"Driver","source":"http://bin.repo/driver.zip","save_as":"driver.zip","certificate":"cert.cer","version":"0.01"},
-#If no save_as is defined then expect the file relative to software_depot
-    {"name":"Driver","source":"driver.zip","certificate":"cert.cer","version":"0.01"}
-  ]
-```
-
-*This recipe is for the moment specific to 64bit Windows installations. For drivers whose publisher is untrusted you will need to include the publisher's certificate in the cookbook. It will not work at all with unsigned drivers*
-
-## [packages.rb](recipes/packages.rb)
-
-This recipe provides three ways for software installation: installer-driven, from a zip file or through [chocolatey](https://chocolatey.org/).
-
-Each method is also usable separately (installer_packages, zip_packages and choco_packages respectively).
+Each method is also usable separately (use installer_packages, zip_packages and choco_packages in the recipe list respectively).
 
 ### Installer driven
 
@@ -103,32 +19,51 @@ The `installer_packages` attribute expects an array of installer definitions.
 
 Each installer definition is a hash with parameters:
 
-  * name - Must match the name appearing in "Uninstall Programs" in the Control Panel.
-  * source & save_as - The URL from where the installer can be downloaded and the filename for the downloaded content (relative to `sofware_depot`)
-  * unpack - Sometimes installers are packaged in zip files (even with HTTP compression people still do that!). 'unpack' defines a relative path to put the zip contents in so that we can get to the installer
-  * installer - if no cache is used (source & save_as are ommited) installer should be the name to the installer executable. Relative paths are relative to `software_depot`
-  * version - The software version
-  * options - command line options to pass to the installer
-  * type - when "custom" then Chef will not try to guess the type and use the path options only.
-  * timeout - Time in seconds to wait for the installer to finish. Default is 600
-  * exit_codes - An optional list of additional exit codes allowed. If given an exit code within the list it will be interpreted as successful installation. Default is an empty list.
+* name - Must match the name appearing in "Uninstall Programs" in the Control Panel.
+* source & save_as - The URL from where the installer can be downloaded and the filename for the downloaded content (relative to `sofware_depot`)
+* unpack - Sometimes installers are packaged in zip files (even with HTTP compression people still do that!). 'unpack' defines a relative path to put the zip contents in so that we can get to the installer
+* installer - if no cache is used (source & save_as are ommited) installer should be the name to the installer executable. Relative paths are relative to `software_depot`
+* version - The software version
+* options - command line options to pass to the installer
+* type - when "custom" then Chef will not try to guess the type and use the path options only.
+* timeout - Time in seconds to wait for the installer to finish. Default is 600
+* exit_codes - An optional list of additional exit codes allowed. If given an exit code within the list it will be interpreted as successful installation. Default is an empty list.
 
 The installers need to be capable of operating unattended (silent or quiet mode).
+
+**Examples:**
+Download the installer,cache it locally and execute it.
 
 ```json
 {
   "installer_packages": [
-#This entry will download the installer and cache it locally
     {"name":"Microsoft .NET Framework 4.5",
       "source":"ftp://bin.repo/dotnetfx45_full_x86_x64.exe","save_as":"dotnetfx45_full_x86_x64.exe",
       "version":"4.5.50709","options":"/passive /norestart","type":"custom"
-    },
-#This entry expects the installer at software/VisualStudio2013/vs_professional.exe and will fail if it is not present
+    }
+  ]
+}
+```
+
+This entry expects the installer at software/VisualStudio2013/vs_professional.exe and will fail if it is not present
+
+```json
+{
+  "installer_packages": [
     {"name":"Microsoft Visual Studio Professional 2013 with Update 4",
       "installer":"VisualStudio2013\\vs_professional.exe",
-      "version":"12.0.31101","type":"custom","timeout":60000,"options":"/Passive /LOG C:\\VS_2013_U3.log /NoRestart /NoWeb /NoRefresh /CustomInstallPath C:\\tools\\VisualStudio2013\\"
-    },
-#This entry downloads an installer wrapped in a .zip file, unpacks and then executes
+      "version":"12.0.31101","type":"custom","timeout":60000,
+      "options":"/Passive /LOG C:\\VS_2013_U3.log /NoRestart /NoWeb /NoRefresh /CustomInstallPath C:\\tools\\VisualStudio2013\\"
+    }
+  ]
+}
+```
+
+This entry downloads an installer wrapped in a .zip file, unpacks and then executes
+
+```json
+{
+  "installer_packages": [
     {"name":"Slik Subversion 1.9.4 (x64)",
       "source":"https://sliksvn.com/pub/Slik-Subversion-1.9.4-x64.zip","save_as":"Slik-Subversion-1.9.4-x64.zip",
       "unpack":"Slik-Subversion-1.9.4-x64/","installer":"Slik-Subversion-1.9.4-x64/Slik-Subversion-1.9.4-x64.msi",
@@ -144,21 +79,30 @@ The `zip_packages` attribute expects an array of zip definitions.
 
 Each zip definition is a hash with parameters:
 
-  * archive - defines the filename for the package if no cache is used (source & save_as are ommited). Relative to `sofware_depot`
-  * source & save_as - The URL from where the package can be downloaded and the filename for the downloaded content (relative to `sofware_depot`)
-  * unpack - location to unpack the archive
-  * version - the version of the software
+* archive - defines the filename for the package if no cache is used (source & save_as are ommited). Relative to `sofware_depot`
+* source & save_as - The URL from where the package can be downloaded and the filename for the downloaded content (relative to `sofware_depot`)
+* unpack - location to unpack the archive
+* version - the version of the software
 
-Example:
+**Examples:**
+
+This entry downloads the file and caches it in software_depot before unpacking
 
 ```json
 {
   "zip_packages": [
-####This entry downloads the file and caches it in software_depot before unpacking
     {"source":"ftp://bin.repo/foo.zip","save_as":"foo.zip",
       "version":"0.0","unpack":"c:/tools/foo"
-    },
-####This entry expects the package in the software_depot directory
+    }
+  ]
+}
+```
+
+This entry expects the package in the *software_depot* directory
+
+```json
+{
+  "zip_packages": [
     {"archive":"foo.zip",
       "version":"0.0","unpack":"c:/tools/foo"
     }
@@ -172,27 +116,58 @@ The `choco_packages` attribute expects an array of chocolatey package definition
 
 Each package definition is a hash with parameters:
 
-  * name - name of the package
-  * source - the source from which to install the package (choco `--source` flag)
-  * version - version of the package to use
-  * options - commandline options to be passed to chocolatey directly
-  * params - options to be passed to the package installer (the --package option).
-  * exit_codes - An optional list of additional exit codes allowed. If given an exit code within the list it will be interpreted as successful installation. Default is an empty list.
+* name - name of the package
+* source - the source from which to install the package (choco `--source` flag)
+* version - version of the package to use
+* options - commandline options to be passed to chocolatey directly
+* params - options to be passed to the package installer (the --package option).
+* exit_codes - An optional list of additional exit codes allowed. If given an exit code within the list it will be interpreted as successful installation. Default is an empty list.
   
 All parameters but `name` are optional.
 
-Example: 
+Example:
+
 ```json
 {
-  "name":"Ruby",
-  "version":"2.4.3.1",
-  "params":"/InstallDir=c:\\tools\\ruby"
+  "choco_packages": [
+    {
+      "name":"Ruby",
+      "version":"2.4.3.1",
+      "params":"/InstallDir=c:\\tools\\ruby"
+    }
+  ]
 }
 ```
 
-## [environment.rb](recipes/environment.rb)
+## windev::depot
 
-Provides an easy way to define environment variables in JSON configurations.
+The [depot](recipes/depot.rb) recipe sets up the local software cache. It is used by all recipes that install software.
+
+The location of the local software is specified in the *software_depot* attribute.
+
+The default value for *software_depot* is 'software', which will create the directory at the point of chef's execution.
+
+Example:
+
+```json
+{"software_depot": "software"}
+```
+
+You can define a node attribute 'cache' to specify packages to download and cache locally in software_depot.
+'cache' is an array of hashes:
+
+```json
+{
+  "software_depot": "software",
+  "cache":[{"source":"http://bin.repo/foo.zip","save_as":"foo.zip"}]
+}
+```
+
+*This is a helper feature for downloading packages that are later manually installed (as is the case with unsigned drivers). Generally it is not needed if the installers are well behaved (but many are not).*
+
+## windev::environment
+
+[environment.rb](recipes/environment.rb) Provides an easy way to define environment variables in JSON configurations.
 
 Provide an _environment_ attribute that points to a hash of 'name'->'value' for the environment variables you want to define.
 
@@ -206,13 +181,66 @@ Example:
     }
 ```
 
-# Resource providers
+## windev::features
+
+[features.rb](recipes/features.rb)
+
+* Deactivates the action center
+* Deactivates the Windows firewall
+
+and uninstalls a list of Windows features provided in `node['windows_features']['remove']`
+
+Example:
+
+```json
+{"windows_features": {
+    "remove": ["MediaPlayback","WindowsMediaPlayer","MediaCenter","TabletPCOC","FaxServicesClientPackage",
+        "Xps-Foundation-Xps-Viewer","Printing-XPSServices-Features","Internet-Explorer-Optional-amd64"]}
+}
+```
+
+## windev::drivers
+
+[drivers.rb](recipes/drivers.rb) installs Windows drivers using dpinst.
+
+The way it works is that it expects a zip file with the driver files (the .inf and .cat file etc.) that also contains the dpinst utility. The LWRP is relatively smart and will match several versions of the dpinst filename (dpinst_amd64, dpinst_x64 etc.). It will also create an automation configuration (dpinst.xml) if one is not provided.
+
+Optionally you can provide a certificate (add it to the files/default in the cookbook) to be added to the trusted publishers in the windows certificate store.
+
+The certificate should either be a part of the driver package or provided in the cookbook's files.
+
+```ruby
+"drivers":[
+    {"name":"Driver","source":"http://bin.repo/driver.zip","save_as":"driver.zip","certificate":"cert.cer","version":"0.01"},
+#If no save_as is defined then expect the file relative to software_depot
+    {"name":"Driver","source":"driver.zip","certificate":"cert.cer","version":"0.01"}
+  ]
+```
+
+*This recipe is for the moment specific to 64bit Windows installations. For drivers whose publisher is untrusted you will need to include the publisher's certificate in the cookbook. It will not work at all with unsigned drivers*.
+
+## windev::auto_chef
+
+[auto_chef](recipes/auto_chef.rb) works around the need to reboot Windows multiple times during a Chef run in a chef-solo/chef-zero setting.
+
+It creates a temporary admin user and registers an auto logon script so that in case of a reboot the run can continue.
+
+The auto logon script is controlled via the environment variables CHEF_SCRIPT and CHEF_CONFIG.
+
+CHEF_SCRIPT is the script and CHEF_CONFIG is passed as a parameter to it.
+
+The remove_auto_chef recipe undoes all changes effected by auto_chef.
+
+The idea is you use auto_chef in the beginning, add any recipes that require or cause reboots and as long as you don't get yourself in an endless reboot loop you clean up at the end with remove_auto_chef.
+
+*NOTE for users of vagrant*: if you are running your scripts from c:\vagrant then auto_chef will inexplicably do nothing.
+
+This happens because Windows runs the startup scripts before mounting the network shares, so the startup fails to find the script.
+
+## Resource providers
 
 The cookbook offers two LWRPs:
 
 cache_package will download a package from a URL to a local directory. It is used heavily in the [packages](recipes/packages.rb) recipe
 
 install_driver performs Windows driver installations. As an example look in the [drivers](recipes/drivers.rb) recipe
-
-----
-<sup>1</sup>GodMode is a special Windows folder providing access to all configuration options

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email 'var@zuehlke.com'
 license          'MIT'
 description      'Configures Windows'
 long_description 'Configures a Windows installation. Parameters include the list of Windows features to remove and data on the installer packages to be added'
-version          '0.8.4'
-chef_version '>= 12.7' if respond_to?(:chef_version)
+version          '1.0.0'
+chef_version '>= 14.0' if respond_to?(:chef_version)
 issues_url 'https://github.com/Zuehlke/cookbook-windev/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/Zuehlke/cookbook-windev' if respond_to?(:source_url)
 
 supports 'windows'
 
-depends 'windows',"~>3.4.4"
-depends 'chocolatey','~>1.2.1'
+depends 'windows',"~>6.0"
+depends 'chocolatey','~>2.0'

--- a/recipes/choco_packages.rb
+++ b/recipes/choco_packages.rb
@@ -9,7 +9,6 @@ include_recipe 'windev::depot'
 ::Chef::Recipe.send(:include, Windows::Helper)
 
 choco_packages=node.fetch('choco_packages',[])
-choco_packages=node.fetch('choco_packages',[])
 
 unless choco_packages.empty?
   include_recipe 'chocolatey::default'
@@ -21,15 +20,19 @@ choco_packages.each do |pkg|
     pkg_version=pkg.fetch("version","")
     pkg_params=pkg.fetch("params","")
 
+    package_action=:install
+    package_action=:upgrade if pkg.fetch("upgrade",false)
+
     if !pkg_params.empty?
       pkg_options<<" --parameters #{pkg_params}"
     end
+
     chocolatey_package pkg["name"] do
       version pkg_version unless pkg_version.empty?
       source pkg_source unless pkg_source.empty?
       options pkg_options unless pkg_options.empty?
       returns [0,3010] + pkg.fetch('exit_codes', [])
-      action :install
-    end
+      action package_action
+    end 
   end
 end

--- a/recipes/features.rb
+++ b/recipes/features.rb
@@ -10,12 +10,6 @@ node['windows_features']['remove'].each do |feat|
   end
 end
 
-ruby_block "GodMode" do
-  block do
-    FileUtils.mkdir_p "#{ENV['USERPROFILE']}\\Desktop\\GodMode.{ED7BA470-8E54-465E-825C-99712043E01C}"
-  end
-end
-
 batch "firewall off" do
   code <<-EOT
   NetSh Advfirewall set allprofiles state off


### PR DESCRIPTION
Bring the cookbook to the here and now and see what shakes loose.

* Update the cookbook dependnecies and the minimum required Chef version. 
* Drop any odd Win7 tricks left in the code base (see God Mode).
* Update the development environment (ruby version, gems and CI)
* Add the chocolatey update functionality from #36 

Since we're updating the minimum required Chef version this is going to be a major version update -> Hello 1.0.0

