### PR TITLE
Fix handling of params for choco packages

### DIFF
--- a/recipes/choco_packages.rb
+++ b/recipes/choco_packages.rb
@@ -24,7 +24,8 @@ choco_packages.each do |pkg|
     package_action=:upgrade if pkg.fetch("upgrade",false)
 
     if !pkg_params.empty?
-      pkg_options<<" --parameters #{pkg_params}"
+      pkg_options<<"--parameters"
+      pkg_options<<"#{pkg_params}"
     end
 
     chocolatey_package pkg["name"] do


### PR DESCRIPTION
This PR fixes the handling of additional "params" that can be passed when installing choco-packages.

Apparently the handling of the choco command changed and parameters are now passed as an array which results in exec args like this for example:

> ["C:\\ProgramData\\chocolatey/bin/choco.exe", "install", "-y", " --parameters /Password:postgres", "postgresql12"]

Note the leading space befor the two dashes for the parameters argument and that the value for the argument is passed in the same argv entry.