### PR TITLE
Fix using options in choco packages

### DIFF
--- a/recipes/choco_packages.rb
+++ b/recipes/choco_packages.rb
@@ -16,7 +16,7 @@ end
 choco_packages.each do |pkg|
   if pkg["name"]
     pkg_source=pkg.fetch("source","")
-    pkg_options=pkg.fetch("options","")
+    pkg_options=pkg.fetch("options",[])
     pkg_version=pkg.fetch("version","")
     pkg_params=pkg.fetch("params","")
 
@@ -24,8 +24,9 @@ choco_packages.each do |pkg|
     package_action=:upgrade if pkg.fetch("upgrade",false)
 
     if !pkg_params.empty?
+      pkg_options = pkg_options.dup
       pkg_options<<"--parameters"
-      pkg_options<<"#{pkg_params}"
+      pkg_options<<pkg_params
     end
 
     chocolatey_package pkg["name"] do


### PR DESCRIPTION
This change is related to PR #49 and exists for the same reason.
Since chef passes the parameters to choco as an array the options can no longer be a plain string. This becomes apparent when using options together with params or when using more than one option since the entire string of options is then passed as one option to choco.

For example when specifying options "--x86 --ia test" and params the exec args become:
> ["C:\ProgramData\chocolatey/bin/choco.exe", "install", "-y", "--x86 --ia test--parameters /Password:postgres", "postgresql12"]

instead of:

> ["C:\ProgramData\chocolatey/bin/choco.exe", "install", "-y", "--x86", "--ia", "test", "--parameters /Password:postgres", "postgresql12"]

Note that here are actually 2 issues that are caused by this:
1. missing space between the last option and the params
2. all options are passed as a single option

I suggest switching to an array for the options which works fine and fixes both issues. However existing cookbooks that use options would have to be changed to use arrays instead of strings for specifying options.